### PR TITLE
fix: Update Instagram credentials path

### DIFF
--- a/accounts.json
+++ b/accounts.json
@@ -17,7 +17,7 @@
         },
         "instagram": {
           "enabled": true,
-          "credentials": "credentials/instagram_tech.json",
+          "credentials": "instagram_session.json",
           "username": null
         }
       },


### PR DESCRIPTION
Fixed Instagram upload by updating accounts.json to use the correct session file path (instagram_session.json instead of credentials/instagram_tech.json).